### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-release-labels.yml
+++ b/.github/workflows/pr-release-labels.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize, reopened, edited]
 
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
 jobs:
   check-release-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   release-please:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4


### PR DESCRIPTION
Potential fix for [https://github.com/mitchs-dev/dislo/security/code-scanning/3](https://github.com/mitchs-dev/dislo/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Since the `release-please` action is used to automate releases, it likely requires `contents: write` to create release tags and update files in the repository. We will add this permission at the job level to limit its scope to the `release-please` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
